### PR TITLE
Fix PHP 8 warning

### DIFF
--- a/Classes/ViewHelpers/FlexformViewHelper.php
+++ b/Classes/ViewHelpers/FlexformViewHelper.php
@@ -46,7 +46,7 @@ class FlexformViewHelper extends AbstractViewHelper
 		$extraClass['extraClass_five'] = '';
 		$extraClass['extraClass_six'] = '';
 
-		if ( $flexconf['equalWidth'] ) {
+		if ( !empty($flexconf['equalWidth']) ) {
 			$colOne = 'col';
 			$colTwo = 'col';
 			$colThree = 'col';


### PR DESCRIPTION
I know, version 2.x is pretty old. But I found a PHP 8 warning problem.

![image](https://github.com/user-attachments/assets/7245b9f6-21ec-435e-bc64-0f3c76689ebf)
